### PR TITLE
FastaHandler: Better AsciiLineReader warning handling

### DIFF
--- a/VariantCaller/src/main/java/com/epam/bioinf/variantcaller/handlers/FastaHandler.java
+++ b/VariantCaller/src/main/java/com/epam/bioinf/variantcaller/handlers/FastaHandler.java
@@ -10,8 +10,6 @@ import htsjdk.samtools.reference.ReferenceSequence;
 import htsjdk.samtools.util.Log;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintStream;
 import java.nio.file.Path;
 
 /**
@@ -45,10 +43,12 @@ public class FastaHandler {
    */
   private FastaSequenceIndex getSequenceIndexFileWithoutWarning(Path fastaPath)
       throws IOException {
-    Log.setGlobalLogLevel(Log.LogLevel.ERROR);
-    FastaSequenceIndex fastaSequenceIndex = FastaSequenceIndexCreator.buildFromFasta(fastaPath);
-    Log.setGlobalLogLevel(Log.LogLevel.INFO);
-    return fastaSequenceIndex;
+    try {
+      Log.setGlobalLogLevel(Log.LogLevel.ERROR);
+      return FastaSequenceIndexCreator.buildFromFasta(fastaPath);
+    } finally {
+      Log.setGlobalLogLevel(Log.LogLevel.INFO);
+    }
   }
 
   /**

--- a/VariantCaller/src/main/java/com/epam/bioinf/variantcaller/handlers/FastaHandler.java
+++ b/VariantCaller/src/main/java/com/epam/bioinf/variantcaller/handlers/FastaHandler.java
@@ -7,6 +7,7 @@ import htsjdk.samtools.reference.FastaSequenceIndex;
 import htsjdk.samtools.reference.FastaSequenceIndexCreator;
 import htsjdk.samtools.reference.IndexedFastaSequenceFile;
 import htsjdk.samtools.reference.ReferenceSequence;
+import htsjdk.samtools.util.Log;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -22,7 +23,6 @@ public class FastaHandler {
 
   /**
    * Constructor creates indexed sequence file and stores it.
-   * Unavoidable AsciiLineReader warning is redirected to nullOutputStream
    * Throwable exception is handled by ParsedArguments
    *
    * @param parsedArguments parsedArguments with validated path to fasta file
@@ -39,13 +39,15 @@ public class FastaHandler {
     }
   }
 
+  /**
+   * Method to get index fasta file without getting warning.
+   * Throwable exception is handled by ParsedArguments
+   */
   private FastaSequenceIndex getSequenceIndexFileWithoutWarning(Path fastaPath)
       throws IOException {
-    // Temporary redirection of AsciiLineReader warning
-    final PrintStream stdErr = System.err;
-    System.setErr(new PrintStream(OutputStream.nullOutputStream(), true, "utf-8"));
+    Log.setGlobalLogLevel(Log.LogLevel.ERROR);
     FastaSequenceIndex fastaSequenceIndex = FastaSequenceIndexCreator.buildFromFasta(fastaPath);
-    System.setErr(stdErr);
+    Log.setGlobalLogLevel(Log.LogLevel.INFO);
     return fastaSequenceIndex;
   }
 

--- a/VariantCaller/src/main/java/com/epam/bioinf/variantcaller/handlers/FastaHandler.java
+++ b/VariantCaller/src/main/java/com/epam/bioinf/variantcaller/handlers/FastaHandler.java
@@ -3,9 +3,15 @@ package com.epam.bioinf.variantcaller.handlers;
 import com.epam.bioinf.variantcaller.cmdline.ParsedArguments;
 import com.epam.bioinf.variantcaller.exceptions.handlers.fasta.FastaHandlerUnableToFindEntryException;
 import htsjdk.samtools.SAMException;
-import htsjdk.samtools.reference.*;
+import htsjdk.samtools.reference.FastaSequenceIndex;
+import htsjdk.samtools.reference.FastaSequenceIndexCreator;
+import htsjdk.samtools.reference.IndexedFastaSequenceFile;
+import htsjdk.samtools.reference.ReferenceSequence;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
 
 /**
  * Class holds a reference file with sequences and performs work with it.
@@ -16,26 +22,39 @@ public class FastaHandler {
 
   /**
    * Constructor creates indexed sequence file and stores it.
+   * Unavoidable AsciiLineReader warning is redirected to nullOutputStream
    * Throwable exception is handled by ParsedArguments
+   *
    * @param parsedArguments parsedArguments with validated path to fasta file
    * @see ParsedArguments
    */
   public FastaHandler(ParsedArguments parsedArguments) {
     try {
-      FastaSequenceIndex fastaSequenceIndex = FastaSequenceIndexCreator
-          .buildFromFasta(parsedArguments.getFastaPath());
-      fastaSequenceFile = new IndexedFastaSequenceFile(
-          parsedArguments.getFastaPath(), fastaSequenceIndex);
+      FastaSequenceIndex fastaSequenceIndex =
+          getSequenceIndexFileWithoutWarning(parsedArguments.getFastaPath());
+      fastaSequenceFile =
+          new IndexedFastaSequenceFile(parsedArguments.getFastaPath(), fastaSequenceIndex);
     } catch (IOException e) { // Handled by ParsedArguments
       e.printStackTrace();
     }
   }
 
+  private FastaSequenceIndex getSequenceIndexFileWithoutWarning(Path fastaPath)
+      throws IOException {
+    // Temporary redirection of AsciiLineReader warning
+    final PrintStream stdErr = System.err;
+    System.setErr(new PrintStream(OutputStream.nullOutputStream(), true, "utf-8"));
+    FastaSequenceIndex fastaSequenceIndex = FastaSequenceIndexCreator.buildFromFasta(fastaPath);
+    System.setErr(stdErr);
+    return fastaSequenceIndex;
+  }
+
   /**
    * Return sequence at specified contig and range
+   *
    * @param contig reference chromosome
-   * @param start range start index
-   * @param stop range end index
+   * @param start  range start index
+   * @param stop   range end index
    * @return ReferenceSequence
    */
   public ReferenceSequence getSubsequence(String contig, long start, long stop) {


### PR DESCRIPTION
# FastaHandler: Better AsciiLineReader warning handling

## Description

Вынесены изменения касающиеся предупреждения AsciiLineReader из #41 .

Предупреждение появляется при попытке проиндексировать .fasta файл. Так как оно не влияет на работоспособность было решено его игнорировать.

Предупреждение: 

> Creating an indexable source for an AsciiFeatureCodec using a stream that is neither a PositionalBufferedStream nor a BlockCompressedInputStream

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
